### PR TITLE
[packaging] BuildRequire systemd via pkgconfig. JB#55010

### DIFF
--- a/rpm/alsa-utils.spec
+++ b/rpm/alsa-utils.spec
@@ -17,9 +17,9 @@ BuildRequires:  autoconf
 BuildRequires:  automake
 BuildRequires:  libtool
 BuildRequires:  pkgconfig(alsa) >= %{alsa_version}
+BuildRequires:  pkgconfig(systemd)
 BuildRequires:  pkgconfig(ncurses)
 BuildRequires:  gettext-devel
-BuildRequires:  systemd-devel
 Conflicts:  udev < 062
 
 %description


### PR DESCRIPTION
This allows to pick systemd-mini inside the builder instead of full
systemd.