### PR TITLE
[alsa-utils] Fix alsactl path in udev rules. JB#61167

### DIFF
--- a/rpm/alsa-utils.spec
+++ b/rpm/alsa-utils.spec
@@ -78,7 +78,8 @@ fi
 
 %files -f %{name}.lang
 %defattr(-,root,root,-)
-%doc COPYING README.md
+%license COPYING
+%doc README.md
 %{_udevrulesdir}/*
 %config %{_sysconfdir}/alsa/*
 %{alsacfgdir}/init/*

--- a/rpm/alsa.rules
+++ b/rpm/alsa.rules
@@ -1,4 +1,4 @@
 ACTION=="add", SUBSYSTEM=="sound", KERNEL=="controlC*", \
-  RUN+="/sbin/alsactl -E ALSA_CONFIG_PATH=/etc/alsa/alsactl.conf --initfile=/usr/lib/alsa/init/00main restore /dev/$name"
+  RUN+="/usr/sbin/alsactl -E ALSA_CONFIG_PATH=/etc/alsa/alsactl.conf --initfile=/usr/lib/alsa/init/00main restore /dev/$name"
 ACTION=="remove", SUBSYSTEM=="sound", KERNEL=="controlC*", \
-  RUN+="/sbin/alsactl -E ALSA_CONFIG_PATH=/etc/alsa/alsactl.conf store /dev/$name"
+  RUN+="/usr/sbin/alsactl -E ALSA_CONFIG_PATH=/etc/alsa/alsactl.conf store /dev/$name"


### PR DESCRIPTION
Use %license for copyright license file.